### PR TITLE
Add locking functionality to redstone repeater

### DIFF
--- a/src/blocks/RedstoneRepeater.js
+++ b/src/blocks/RedstoneRepeater.js
@@ -312,6 +312,7 @@
 		var poweredColour = "rgb(255,0,0)";
 		var unpoweredColour = "rgb(128,0,0)";
 		var unusedColour = "rgb(192,192,192)";
+		var lockedColour = "rgb(64, 64, 64)";
 		var blockMetaData = world.getBlockMetadata(posX, posY, posZ);
 		
  		/*
@@ -322,6 +323,7 @@
 		0x3: 4 tick delay
 		*/
 		var delay = ((blockMetaData & 0xc) >>> 2) + 1;
+		var isLocked = Boolean((blockMetaData & 0x10) >>> 4);
 		
 		var delayColour1 = (this.isRepeaterPowered) ? poweredColour : unpoweredColour;
 		var delayColour2 = (this.isRepeaterPowered) ? poweredColour : unpoweredColour;
@@ -335,6 +337,11 @@
 		if (view == "top") {
 			canvas.save();
 			this.rotateContext(rotated, canvas);
+
+			if (isLocked) {
+				canvas.fillStyle = lockedColour;
+				canvas.fillRect(0, 3, 8, 2);
+			}
 
 			canvas.fillStyle = delayColour1;
 			canvas.fillRect(3, 0, 2, 2);

--- a/src/blocks/RedstoneRepeater.js
+++ b/src/blocks/RedstoneRepeater.js
@@ -100,16 +100,9 @@
 		var blockMetadata = world.getBlockMetadata(posX, posY, posZ);
 		var ignoreTick = this.ignoreTick(world, posX, posY, posZ, blockMetadata);
 		var repeaterDelay = (blockMetadata & 0xc) >> 2;
-		var isLocked = Boolean((blockMetadata & 0x10) >> 4);
-		var isLockedNow = this.isLocked(world, posX, posY, posZ, blockMetadata);
 
-		if (isLocked !== isLockedNow) {
-			var isLockedNowMetadata = Number(isLockedNow) << 4;
-			world.setBlockMetadataWithNotify(posX, posY, posZ, isLockedNowMetadata | blockMetadata & 0xf);
-		}
-
-		if (isLockedNow) {
-			return; // don't trigger update if block is locked
+		if (this.isLocked(world, posX, posY, posZ, blockMetadata)) {
+			return; // don't trigger update if repeater is locked
 		}
 		else if (this.isRepeaterPowered && !ignoreTick) {
 			world.scheduleBlockUpdate(posX, posY, posZ, this.blockID, this.repeaterState[repeaterDelay] * 2);
@@ -322,6 +315,7 @@
 		0x3: 4 tick delay
 		*/
 		var delay = (blockMetaData >>> 2) + 1;
+		var isLocked = this.isLocked(world, posX, posY, posZ, blockMetaData);
 		
 		var delayColour1 = (this.isRepeaterPowered) ? poweredColour : unpoweredColour;
 		var delayColour2 = (this.isRepeaterPowered) ? poweredColour : unpoweredColour;

--- a/src/blocks/RedstoneRepeater.js
+++ b/src/blocks/RedstoneRepeater.js
@@ -34,24 +34,25 @@
 	proto.rotateSelection = function(blockMetadata, amount) {
 		var facing = blockMetadata & 0x3;
 		var delay = blockMetadata & 0xc;
+		var locked = blockMetadata & 0x10;
 		for (var i=0; i<amount; i++) {
 			facing = new Array(1, 2, 3, 0)[facing];
 		}
-		return facing | delay;
+		return facing | delay | locked;
 	};
 	
 	proto.rotateBlock = function(world, posX, posY, posZ) {
 		var blockMetadata = world.getBlockMetadata(posX, posY, posZ);
 		var repeaterOrientation = blockMetadata & 0x3;
 		repeaterOrientation = (repeaterOrientation + 1) & 0x3;
-		world.setBlockAndMetadataWithNotify(posX, posY, posZ, this.blockID, repeaterOrientation | (blockMetadata & 0xc));
+		world.setBlockAndMetadataWithNotify(posX, posY, posZ, this.blockID, repeaterOrientation | (blockMetadata & 0x1c));
 	};
 	
 	proto.blockActivated = function(world, posX, posY, posZ) {
 		var blockMetadata = world.getBlockMetadata(posX, posY, posZ);
 		var repeaterDelay = (blockMetadata & 0xc) >> 0x2;
 		repeaterDelay = repeaterDelay + 1 << 0x2 & 0xc;
-		world.setBlockMetadataWithNotify(posX, posY, posZ, repeaterDelay | blockMetadata & 0x3);
+		world.setBlockMetadataWithNotify(posX, posY, posZ, repeaterDelay | blockMetadata & 0x13);
 		return true;
 	};
 	
@@ -292,7 +293,7 @@
 		0x2: 3 tick delay
 		0x3: 4 tick delay
 		*/
-		var delay = (blockMetaData >>> 2) + 1;
+		var delay = ((blockMetaData & 0xc) >>> 2) + 1;
 		
 		var delayColour1 = (this.isRepeaterPowered) ? poweredColour : unpoweredColour;
 		var delayColour2 = (this.isRepeaterPowered) ? poweredColour : unpoweredColour;

--- a/src/blocks/RedstoneRepeater.js
+++ b/src/blocks/RedstoneRepeater.js
@@ -34,25 +34,24 @@
 	proto.rotateSelection = function(blockMetadata, amount) {
 		var facing = blockMetadata & 0x3;
 		var delay = blockMetadata & 0xc;
-		var locked = blockMetadata & 0x10;
 		for (var i=0; i<amount; i++) {
 			facing = new Array(1, 2, 3, 0)[facing];
 		}
-		return facing | delay | locked;
+		return facing | delay;
 	};
 	
 	proto.rotateBlock = function(world, posX, posY, posZ) {
 		var blockMetadata = world.getBlockMetadata(posX, posY, posZ);
 		var repeaterOrientation = blockMetadata & 0x3;
 		repeaterOrientation = (repeaterOrientation + 1) & 0x3;
-		world.setBlockAndMetadataWithNotify(posX, posY, posZ, this.blockID, repeaterOrientation | (blockMetadata & 0x1c));
+		world.setBlockAndMetadataWithNotify(posX, posY, posZ, this.blockID, repeaterOrientation | (blockMetadata & 0xc));
 	};
 	
 	proto.blockActivated = function(world, posX, posY, posZ) {
 		var blockMetadata = world.getBlockMetadata(posX, posY, posZ);
 		var repeaterDelay = (blockMetadata & 0xc) >> 0x2;
 		repeaterDelay = repeaterDelay + 1 << 0x2 & 0xc;
-		world.setBlockMetadataWithNotify(posX, posY, posZ, repeaterDelay | blockMetadata & 0x13);
+		world.setBlockMetadataWithNotify(posX, posY, posZ, repeaterDelay | blockMetadata & 0x3);
 		return true;
 	};
 	
@@ -322,8 +321,7 @@
 		0x2: 3 tick delay
 		0x3: 4 tick delay
 		*/
-		var delay = ((blockMetaData & 0xc) >>> 2) + 1;
-		var isLocked = Boolean((blockMetaData & 0x10) >>> 4);
+		var delay = (blockMetaData >>> 2) + 1;
 		
 		var delayColour1 = (this.isRepeaterPowered) ? poweredColour : unpoweredColour;
 		var delayColour2 = (this.isRepeaterPowered) ? poweredColour : unpoweredColour;

--- a/src/blocks/RedstoneRepeater.js
+++ b/src/blocks/RedstoneRepeater.js
@@ -122,20 +122,20 @@
 
 	proto.isLocked = function (world, posX, posY, posZ, blockMetadata) {
 		var repeaterDirection= blockMetadata & 3;
+		var repeaterBlockId = world.Block.redstoneRepeaterActive.blockID;
 		switch (repeaterDirection) {
 			case 3:
 			case 1:
-				return world.getBlockId(posX, posY, posZ + 1) == world.Block.redstoneRepeaterActive.blockID
-					|| world.getBlockId(posX, posY, posZ - 1) == world.Block.redstoneRepeaterActive.blockID;
+				return (world.getBlockId(posX, posY, posZ + 1) === repeaterBlockId && world.isBlockProvidingPowerTo(posX, posY, posZ + 1, 3))
+					|| (world.getBlockId(posX, posY, posZ - 1) === repeaterBlockId && world.isBlockProvidingPowerTo(posX, posY, posZ - 1, 2));
 
 			case 0:
 			case 2:
-				return world.getBlockId(posX + 1, posY, posZ) == world.Block.redstoneRepeaterActive.blockID
-					|| world.getBlockId(posX - 1, posY, posZ) == world.Block.redstoneRepeaterActive.blockID;
+				return (world.getBlockId(posX + 1, posY, posZ) === repeaterBlockId && world.isBlockProvidingPowerTo(posX + 1, posY, posZ, 5))
+					|| (world.getBlockId(posX - 1, posY, posZ) === repeaterBlockId && world.isBlockProvidingPowerTo(posX - 1, posY, posZ, 4));
 		}
 		return false;
 	}
-
 	
 	proto.ignoreTick = function (world, posX, posY, posZ, blockMetadata) {
 		var repeaterDirection= blockMetadata & 3;


### PR DESCRIPTION
I've finished implementing this and it seems to work. I know you're busy so I've deployed a test version [here](https://minecraft.olly.fr.to) for quick testing (it's just hosted as a static page as I'm not too familiar with PHP, so none of the saving/loading etc will work I think).

![repeater](https://user-images.githubusercontent.com/6783708/40587959-1f869f5a-619c-11e8-9a59-9f07ecbfcdd2.png)

I put the locked/unlocked boolean state in the repeater block's metadata, this isn't the same as how it works in actual Minecraft, where it's stored in the [block state rather than block data](https://minecraft.gamepedia.com/Redstone_Repeater#Block_data), but I don't think there is such a thing as block state in the simulator right? The metadata now has the rightmost bits as direction (00011), the next two bits are delay (01100), and the leftmost bit is the new locked state (10000).

In order to get this working I had to increase the max block metadata size limit [in JsNbtParser/World_Schematic](https://github.com/JonathanLydall/JsNbtParser/blob/ae89c21b30bade872eb3f3eb4e087cb94ebbc39f/js/World_Schematic.js#L193c), because the limit is currently set to 0xf. Though the error message does say value must be from 0 to 127 (0x1f) so maybe this is okay? In my [test branch](https://github.com/ollyhayes/JavaScript-Redstone-Simulator/branches) I've pulled JsNbtParser into the repository to get it working but for the live version I'm not quite sure how it works because the script tags in [/src/_fileList.txt](https://github.com/ollyhayes/JavaScript-Redstone-Simulator/blob/d950bca4892fe961b7365284c01b7a7c25cbec11/src/_fileList.txt#L10) don't seem to match the files in your [JsNbtParser repository](https://github.com/JonathanLydall/JsNbtParser) on github. Should I submit a pull request to JsNbtParser with that change too?.

Let me know what you think, happy to make any changes you think are necessary.

(This fixes issue #1)