### PR TITLE
Some draw fixes

### DIFF
--- a/src/minecraftSimulator.js
+++ b/src/minecraftSimulator.js
@@ -181,6 +181,16 @@ com.mordritch.mcSim.MinecraftSimulator = function() {
 			return Block.unknown;
 		}
 	};
+
+	this.getBlockById = function(blockID) {
+		var Block = this.Block;
+		if (typeof Block.blocksList[blockID] != "undefined") {
+			return Block.blocksList[blockID];
+		}
+		else {
+			return Block.unknown;
+		}
+	}
 	
 	/**
 	 * Returns the name of a type of block at a particular coordinate


### PR DESCRIPTION
Hello!
I have done some fixes when "drawing" blocks, at least from my standpoint.
If you move the mouse too fast, blocks will not become "scattered", but a line of blocks will be put between from the last put block to the current mouse position.
Blocks will now generally replace what currently is on a square.
You cannot put two normally rendered blocks at the same position or two non-normally blocks.
If a block of one of theese kinds is on a square, you can always put a block of the other kind so if there is a redstone torch on a square and you paint with wool, you will get a redstone torch on top of wool.