### PR TITLE
Let coordinates panel be visible even if the mouse is not hovering it.

### DIFF
--- a/css/guiFull.css
+++ b/css/guiFull.css
@@ -524,8 +524,9 @@ body {
 
 #workarea canvas {
 	position: absolute;
-	top: 50px;
+	top: 37px;
 	left: 0;
+	padding: 3px;
 }
 
 #workarea canvas.modelView {

--- a/src/modelViews/ModelView_Canvas_Default.js
+++ b/src/modelViews/ModelView_Canvas_Default.js
@@ -148,7 +148,6 @@
 		
 
 		this.$controls = $('#'+this.containerDomId+' .controls');
-		this.$controls.hide();
 		this.$controls.html(this.getControlsHtml());
 
 		this.$domObject = $('#'+this.elementId);
@@ -167,15 +166,7 @@
 		if (this.noContextMenu == true) this.disableContextMenu();
 		
 		$(window).bind('resize', {t: this}, function(e){e.data.t.windowResize();});
-		this.$controls.parent().bind('mouseenter', {t: this}, function(e) {
-			e.data.t.$controls.show();
-		});
 		
-		this.$controls.parent().bind('mouseleave', {t: this}, function(e) {
-			e.data.t.$controls.hide();
-		});
-
-
 		this.construct();
 		this.constructed = true;
 		this.drawAllBlocks();


### PR DESCRIPTION
Maybe it is only me, but i found it irritating that the cordinates panel dissapears when your mouse is not hovering it, and that leaves a gap above the grid. This commit also adjusts the grid to be aligned with the coordinates panel.