### PR TITLE
Incorrect schema name in README.md?

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,24 +41,17 @@ Prerequisites
             SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
             SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
             SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='TRADITIONAL,ALLOW_INVALID_DATES';
+            
+            -- -----------------------------------------------------
+            -- Schema mordritc_mcrss
+            -- -----------------------------------------------------
+            CREATE SCHEMA IF NOT EXISTS `mordritc_mcrss` DEFAULT CHARACTER SET utf8 ;
+            USE `mordritc_mcrss` ;
 
             -- -----------------------------------------------------
-            -- Schema mydb
+            -- Table `mordritc_mcrss`.`persistantsessions`
             -- -----------------------------------------------------
-            -- -----------------------------------------------------
-            -- Schema mc_rss
-            -- -----------------------------------------------------
-
-            -- -----------------------------------------------------
-            -- Schema mc_rss
-            -- -----------------------------------------------------
-            CREATE SCHEMA IF NOT EXISTS `mc_rss` DEFAULT CHARACTER SET utf8 ;
-            USE `mc_rss` ;
-
-            -- -----------------------------------------------------
-            -- Table `mc_rss`.`persistantsessions`
-            -- -----------------------------------------------------
-            CREATE TABLE IF NOT EXISTS `mc_rss`.`persistantsessions` (
+            CREATE TABLE IF NOT EXISTS `mordritc_mcrss`.`persistantsessions` (
             `id` INT(11) NOT NULL AUTO_INCREMENT,
             `userId` INT(11) NOT NULL,
             `cookieString` VARCHAR(64) NOT NULL,
@@ -71,9 +64,9 @@ Prerequisites
 
 
             -- -----------------------------------------------------
-            -- Table `mc_rss`.`schematics`
+            -- Table `mordritc_mcrss`.`schematics`
             -- -----------------------------------------------------
-            CREATE TABLE IF NOT EXISTS `mc_rss`.`schematics` (
+            CREATE TABLE IF NOT EXISTS `mordritc_mcrss`.`schematics` (
             `id` INT(11) NOT NULL AUTO_INCREMENT,
             `userId` INT(11) NULL DEFAULT NULL,
             `derivedFromId` INT(11) NULL DEFAULT NULL,
@@ -96,9 +89,9 @@ Prerequisites
 
 
             -- -----------------------------------------------------
-            -- Table `mc_rss`.`schematics_tempholder`
+            -- Table `mordritc_mcrss`.`schematics_tempholder`
             -- -----------------------------------------------------
-            CREATE TABLE IF NOT EXISTS `mc_rss`.`schematics_tempholder` (
+            CREATE TABLE IF NOT EXISTS `mordritc_mcrss`.`schematics_tempholder` (
             `id` INT(11) NOT NULL AUTO_INCREMENT,
             `timestamp` DATETIME NOT NULL,
             `data` MEDIUMBLOB NOT NULL,
@@ -110,9 +103,9 @@ Prerequisites
 
 
             -- -----------------------------------------------------
-            -- Table `mc_rss`.`users`
+            -- Table `mordritc_mcrss`.`users`
             -- -----------------------------------------------------
-            CREATE TABLE IF NOT EXISTS `mc_rss`.`users` (
+            CREATE TABLE IF NOT EXISTS `mordritc_mcrss`.`users` (
             `id` INT(11) NOT NULL AUTO_INCREMENT,
             `emailAddress` VARCHAR(45) CHARACTER SET 'latin1' NOT NULL,
             `displayName` VARCHAR(45) CHARACTER SET 'utf8' COLLATE 'utf8_unicode_ci' NOT NULL,


### PR DESCRIPTION
I have changed the sql to create the schema with the name mordritc_mcrss  instead of mc_rss so the schema will get the same name as the one in the config.