### PR TITLE
Fixing piston, door and lever rotation using the "Rotate Block Tool"

### DIFF
--- a/src/World.js
+++ b/src/World.js
@@ -799,14 +799,12 @@ com.mordritch.mcSim.World = function(BlockObj, worldDataObj) {
 	this.setBlockMetadataWithNotify = function(posX, posY, posZ, blockMetadata) {
 		if (this.setBlockMetadata(posX, posY, posZ, blockMetadata))
 		{
-				var blockID = this.getBlockId(posX, posY, posZ);
-				if(this.Block.blocksList[blockID & 0xff].requiresSelfNotify)
-				{
-					this.notifyBlockChange(posX, posY, posZ, blockID);
-				}
-				else {
-					this.notifyBlocksOfNeighborChange(posX, posY, posZ, blockID);
-				}
+			var blockID = this.getBlockId(posX, posY, posZ);
+			this.notifyBlockChange(posX, posY, posZ, blockID);
+			if(!this.Block.blocksList[blockID & 0xff].requiresSelfNotify)
+			{
+				this.notifyBlocksOfNeighborChange(posX, posY, posZ, blockID);
+			}
 		}
 	};
 	


### PR DESCRIPTION
This fix always calls this.notifyBlockChange(posX, posY, posZ, blockID); in World.setBlockMetadataWithNotify, just like setBlockAndMetadataWithNotify,

Fixing https://github.com/JonathanLydall/JavaScript-Redstone-Simulator/issues/13.